### PR TITLE
Repo restructure first working imx deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # fprime-scales
-Sub-repo for Cal Poly Pomona F Prime common code
+Sub-repo for Cal Poly Pomona F Prime common code. Includes cmake files for SCALES Hardware, and other things soon to come.

--- a/SCALES/Components/CMakeLists.txt
+++ b/SCALES/Components/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/FPManager")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/JetsonPowerStateManager")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/MLManager")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/PowerThermalManager")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/SpacecraftStateManager")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/StorageManager")

--- a/SCALES/Components/JetsonPowerStateManager/JetsonPowerStateManager.fpp
+++ b/SCALES/Components/JetsonPowerStateManager/JetsonPowerStateManager.fpp
@@ -1,17 +1,17 @@
-module components {
+module SCALES {
   # Defining types needed for this component
-  enum PowerLevel: U8 {
-    WATTS_15 = 0 @< 15 Watts power state
-    WATTS_30 = 1 @< 30 Watts power state
-    WATTS_50 = 2 @< 50 Watts power state
-    UNKNOWN = 3 @< Power state not determined
-  }
+  # enum PowerLevel: U8 {
+  #   WATTS_15 = 0 @< 15 Watts power state
+  #   WATTS_30 = 1 @< 30 Watts power state
+  #   WATTS_50 = 2 @< 50 Watts power state
+  #   UNKNOWN = 3 @< Power state not determined
+  # }
   
-  struct PowerState {
-    level: PowerLevel @< Current power level
-    timestamp: U32 @< Timestamp of state
-    textFilePath: string size 128 @< Path to power state config file
-  }
+  # struct PowerState {
+  #   level: PowerLevel @< Current power level
+  #   timestamp: U32 @< Timestamp of state
+  #   textFilePath: string size 128 @< Path to power state config file
+  # }
 
   @ Controls configuration, enabling state transitions and power cycle operations
   active component JetsonPowerStateManager {
@@ -27,11 +27,11 @@ module components {
     @ Port for sending ping responses 
     output port pingSend: Svc.Ping
     
-    @ Port for receiving power state change requests (e.g., 15W, 30W, 50W)
-    async input port powerStateReceive: components.PowerState
+    # @ Port for receiving power state change requests (e.g., 15W, 30W, 50W)
+    # async input port powerStateReceive: components.PowerState
     
-    @ Port for sending current power state information
-    output port powerStateSend: components.PowerState
+    # @ Port for sending current power state information
+    # output port powerStateSend: components.PowerState
 
     @ Port that receives the rate group "tick" for ping intervals
     async input port schedIn: Svc.Sched
@@ -72,7 +72,7 @@ module components {
     
     @ Command to set the Jetson power state
     async command SET_POWER_STATE(
-      state: components.PowerLevel @< Power level to set (15W, 30W, or 50W)
+      $state: PowerLevel @< Power level to set (15W, 30W, or 50W)
     )
     
     @ Command to request current power state
@@ -87,12 +87,12 @@ module components {
     
     @ Event indicating power state change successful
     event POWER_STATE_CHANGED(
-      level: components.PowerLevel @< The new power level
+      level: PowerLevel @< The new power level
     ) severity activity high id 0 format "Jetson power state changed to {}"
     
     @ Event indicating power state change failed
     event POWER_STATE_CHANGE_FAILED(
-      requested: components.PowerLevel @< The requested power level
+      requested: PowerLevel @< The requested power level
       reason: string size 64 @< Reason for failure
     ) severity warning high id 1 format "Failed to change Jetson power state to {}: {}"
     
@@ -119,7 +119,7 @@ module components {
     ###############################################################################
     
     @ Current power state of Jetson
-    telemetry CurrentPowerState: components.PowerLevel
+    telemetry CurrentPowerState: PowerLevel
     
     @ Number of successful ping operations
     telemetry PingSuccessCount: U32

--- a/SCALES/Components/PowerThermalManager/PowerThermalManager.fpp
+++ b/SCALES/Components/PowerThermalManager/PowerThermalManager.fpp
@@ -1,42 +1,35 @@
-module components {
+module SCALES {
 
   # Defining types needed for this component
-  enum SystemState: U8 {
-    STANDBY = 0 @< System in standby mode
-    NORMAL = 1 @< System in normal operation
-    SAFE = 2 @< System in safe mode
-    CRITICAL = 3 @< System in critical mode
-    UNKNOWN = 4 @< System state not determined
-  }
   
-  struct PowerReading {
-    voltage: F32 @< Voltage reading in volts
-    current: F32 @< Current reading in amps
-    power: F32 @< Power consumption in watts
-    sourceId: U8 @< ID of the power source/sensor
-    timestamp: U32 @< Timestamp of reading
-  }
+  # struct PowerReading {
+  #   voltage: F32 @< Voltage reading in volts
+  #   current: F32 @< Current reading in amps
+  #   power: F32 @< Power consumption in watts
+  #   sourceId: U8 @< ID of the power source/sensor
+  #   timestamp: U32 @< Timestamp of reading
+  # }
   
-  struct ThermalReading {
-    temperature: F32 @< Temperature in degrees Celsius
-    sensorId: U8 @< ID of the thermal sensor
-    location: string size 32 @< Description of sensor location
-    timestamp: U32 @< Timestamp of reading
-  }
+  # struct ThermalReading {
+  #   temperature: F32 @< Temperature in degrees Celsius
+  #   sensorId: U8 @< ID of the thermal sensor
+  #   location: string size 32 @< Description of sensor location
+  #   timestamp: U32 @< Timestamp of reading
+  # }
   
-  struct SystemStateData {
-    state: SystemState @< Current spacecraft state
-    timestamp: U32 @< Timestamp of state update
-    modeDescription: string size 64 @< Optional detailed mode description
-  }
+  # struct SystemStateData {
+  #   $state: SystemState @< Current spacecraft state
+  #   timestamp: U32 @< Timestamp of state update
+  #   modeDescription: string size 64 @< Optional detailed mode description
+  # }
   
-  struct PowerThermalStatus {
-    powerReadings: PowerReading @< Power readings
-    thermalReadings: ThermalReading @< Thermal readings
-    systemRecommendation: SystemState @< Recommended system state based on power/thermal
-    criticalFlag: bool @< Flag indicating if any readings are in critical range
-    timestamp: U32 @< Timestamp of status update
-  }
+  # struct PowerThermalStatus {
+  #   powerReadings: PowerReading @< Power readings
+  #   thermalReadings: ThermalReading @< Thermal readings
+  #   systemRecommendation: SystemState @< Recommended system state based on power/thermal
+  #   criticalFlag: bool @< Flag indicating if any readings are in critical range
+  #   timestamp: U32 @< Timestamp of status update
+  # }
 
   @ Component to manage and monitor power and thermal conditions of the system
   active component PowerThermalManager {
@@ -45,20 +38,20 @@ module components {
     #                                 General Ports                               #
     ###############################################################################
     
-    @ Port for receiving power data
-    async input port powerData: components.PowerReading
+    # @ Port for receiving power data
+    # async input port powerData: components.PowerReading
     
-    @ Port for receiving thermal data
-    async input port thermalData: components.ThermalReading
+    # @ Port for receiving thermal data
+    # async input port thermalData: components.ThermalReading
     
-    @ Input port for receiving system state information
-    async input port systemStateIn: components.SystemStateData
+    # @ Input port for receiving system state information
+    # async input port systemStateIn: components.SystemStateData
     
-    @ Output port for all power and thermal telemetry data
-    output port dataOut: components.PowerThermalStatus
+    # @ Output port for all power and thermal telemetry data
+    # output port dataOut: components.PowerThermalStatus
     
-    @ Output port for sending power/thermal status to SystemResources component
-    output port systemResourcesOut: components.PowerThermalStatus
+    # @ Output port for sending power/thermal status to SystemResources component
+    # output port systemResourcesOut: components.PowerThermalStatus
     
     ###############################################################################
     # Standard AC Ports: Required for Channels, Events, Commands, and Parameters  #
@@ -123,7 +116,7 @@ module components {
       temperature: F32 @< Current temperature
       threshold: F32 @< Warning threshold
       location: string size 32 @< Sensor location
-    ) severity warning high id 0 format "High thermal warning: {} at {} is {°C} (threshold: {°C})"
+    ) severity warning high id 0 format "High thermal warning: {} at {} is {}°C (threshold: {}°C)"
     
     @ Event indicating thermal warning threshold exceeded (lower)
     event THERMAL_WARNING_LOW(
@@ -131,7 +124,7 @@ module components {
       temperature: F32 @< Current temperature
       threshold: F32 @< Warning threshold
       location: string size 32 @< Sensor location
-    ) severity warning high id 11 format "Low thermal warning: {} at {} is {°C} (threshold: {°C})"
+    ) severity warning high id 11 format "Low thermal warning: {} at {} is {}°C (threshold: {}°C)"
     
     @ Event indicating thermal critical threshold exceeded (upper)
     event THERMAL_CRITICAL_HIGH(
@@ -139,7 +132,7 @@ module components {
       temperature: F32 @< Current temperature
       threshold: F32 @< Critical threshold
       location: string size 32 @< Sensor location
-    ) severity warning high id 1 format "CRITICAL HIGH THERMAL: {} at {} is {°C} (threshold: {°C})"
+    ) severity warning high id 1 format "CRITICAL HIGH THERMAL: {} at {} is {}°C (threshold: {}°C)"
     
     @ Event indicating thermal critical threshold exceeded (lower)
     event THERMAL_CRITICAL_LOW(
@@ -147,39 +140,39 @@ module components {
       temperature: F32 @< Current temperature
       threshold: F32 @< Critical threshold
       location: string size 32 @< Sensor location
-    ) severity warning high id 12 format "CRITICAL LOW THERMAL: {} at {} is {°C} (threshold: {°C})"
+    ) severity warning high id 12 format "CRITICAL LOW THERMAL: {} at {} is {}°C (threshold: {}°C)"
     
     @ Event indicating power warning threshold exceeded (upper)
     event POWER_WARNING_HIGH(
       sourceId: U8 @< ID of the power source
       power: F32 @< Current power consumption
       threshold: F32 @< Warning threshold
-    ) severity warning high id 2 format "High power warning: Source {} at {W} (threshold: {W})"
+    ) severity warning high id 2 format "High power warning: Source {} at {}W (threshold: {}W)"
     
     @ Event indicating power warning threshold exceeded (lower)
     event POWER_WARNING_LOW(
       sourceId: U8 @< ID of the power source
       power: F32 @< Current power consumption
       threshold: F32 @< Warning threshold
-    ) severity warning high id 13 format "Low power warning: Source {} at {W} (threshold: {W})"
+    ) severity warning high id 13 format "Low power warning: Source {} at {}W (threshold: {}W)"
     
     @ Event indicating power critical threshold exceeded (upper)
     event POWER_CRITICAL_HIGH(
       sourceId: U8 @< ID of the power source
       power: F32 @< Current power consumption
       threshold: F32 @< Critical threshold
-    ) severity warning high id 3 format "CRITICAL HIGH POWER: Source {} at {W} (threshold: {W})"
+    ) severity warning high id 3 format "CRITICAL HIGH POWER: Source {} at {}W (threshold: {}W)"
     
     @ Event indicating power critical threshold exceeded (lower)
     event POWER_CRITICAL_LOW(
       sourceId: U8 @< ID of the power source
       power: F32 @< Current power consumption
       threshold: F32 @< Critical threshold
-    ) severity warning high id 14 format "CRITICAL LOW POWER: Source {} at {W} (threshold: {W})"
+    ) severity warning high id 14 format "CRITICAL LOW POWER: Source {} at {}W (threshold: {}W)"
     
     @ Event indicating limits updated
     event LIMITS_UPDATED(
-      type: string size 16 @< Type of limit updated (THERMAL or POWER)
+      $type: string size 16 @< Type of limit updated (THERMAL or POWER)
       lowerWarning: F32 @< New lower warning threshold
       upperWarning: F32 @< New upper warning threshold
       lowerCritical: F32 @< New lower critical threshold
@@ -192,7 +185,7 @@ module components {
       power: F32 @< Current power consumption
       lowerLimit: F32 @< Lower limit
       upperLimit: F32 @< Upper limit
-    ) severity warning high id 8 format "Power out of range: Source {} at {W} (limits: {W}-{W})"
+    ) severity warning high id 8 format "Power out of range: Source {} at {}W (limits: {}W-{}W)"
     
     @ Event indicating thermal is out of range
     event THERMAL_OUT_OF_RANGE(
@@ -201,14 +194,14 @@ module components {
       lowerLimit: F32 @< Lower limit
       upperLimit: F32 @< Upper limit
       location: string size 32 @< Sensor location
-    ) severity warning high id 9 format "Thermal out of range: {} at {} is {°C} (limits: {°C}-{°C})"
+    ) severity warning high id 9 format "Thermal out of range: {} at {} is {}°C (limits: {}°C-{}°C)"
     
     @ Event indicating power transition due to state change
     event POWER_TRANSITION(
-      previousState: components.SystemState @< Previous system state
-      newState: components.SystemState @< New system state
+      previousState: SystemState @< Previous system state
+      newState: SystemState @< New system state
       powerChange: F32 @< Change in power consumption
-    ) severity activity high id 10 format "Power transition from {} to {}: {W} change"
+    ) severity activity high id 10 format "Power transition from {} to {}: {}W change"
     
     ###############################################################################
     #                                 Telemetry                                   #
@@ -251,6 +244,6 @@ module components {
     telemetry PowerLowerCriticalThreshold: F32
     
     @ Current system state
-    telemetry CurrentSystemState: components.SystemState
+    telemetry CurrentSystemState: SystemState
   }
 }

--- a/SCALES/Components/StorageManager/StorageManager.fpp
+++ b/SCALES/Components/StorageManager/StorageManager.fpp
@@ -1,56 +1,35 @@
-module components {
+module SCALES {
 
   # Defining types needed for this component
   
   # Storage status information
-  struct StorageStatus {
-    totalCapacityMB: U32 @< Total storage capacity in MB
-    availableSpaceMB: U32 @< Available storage space in MB
-    usedSpaceMB: U32 @< Used storage space in MB
-    utilizationPercent: F32 @< Storage utilization percentage
-    writeRateKBps: F32 @< Current write rate in KB/s
-    readRateKBps: F32 @< Current read rate in KB/s
-    healthStatus: string size 32 @< Storage health status description
-    timestamp: U32 @< Timestamp of status update
-  }
+  
   
   # System state data from SpacecraftStateManager
-  struct SystemStateData {
-    state: SystemState @< Current spacecraft state
-    timestamp: U32 @< Timestamp of state update
-    availablePowerForStorage: F32 @< Available power allocation for storage operations (Watts)
-    priorityLevel: U8 @< Current priority level for storage operations
-    modeDescription: string size 64 @< Optional detailed mode description
-  }
+
   
   # Enum for system states
-  enum SystemState: U8 {
-    STANDBY = 0 @< System in standby mode
-    NORMAL = 1 @< System in normal operation
-    SAFE = 2 @< System in safe mode
-    CRITICAL = 3 @< System in critical mode
-    UNKNOWN = 4 @< System state not determined
-  }
+  # removed/restructured
   
   # Data structure for component data storage/retrieval
-  struct StorageData {
-    componentId: U8 @< ID of the source/destination component
-    dataType: string size 32 @< Type of data being stored/retrieved
-    dataSize: U32 @< Size of data in bytes
-    priority: U8 @< Priority level of this data (0-255)
-    timestamp: U32 @< Timestamp of data
-    data: Fw.Buffer @< The actual data payload
-  }
+  # struct StorageData {
+  #   componentId: U8 @< ID of the source/destination component
+  #   dataType: string size 32 @< Type of data being stored/retrieved
+  #   dataSize: U32 @< Size of data in bytes
+  #   $priority: U8 @< Priority level of this data (0-255)
+  #   timestamp: U32 @< Timestamp of data
+  #   data: Fw.Buffer @< The actual data payload
+  # }
   
   # Structure for data transfer requests
-  struct DataTransferRequest {
-    sourceComponentId: U8 @< Source component ID
-    destinationComponentId: U8 @< Destination component ID
-    dataType: string size 32 @< Type of data to transfer
-    priority: U8 @< Priority of transfer
-    maxSizeMB: U32 @< Maximum size to transfer in MB
-    timestamp: U32 @< Timestamp of request
-  }
+  # struct DataTransferRequest {
+  #   sourceComponentId: U8 @< Source component ID
+  #   destinationComponentId: U8 @< Destination component ID
+  #   dataType: string size 32 @< Type of data to transfer
+  #   $priority: U8 @< Priority of transfer
+  #   maxSizeMB: U32 @< Maximum size to transfer in MB
+  #   timestamp: U32 @< Timestamp of request
+  # }
 
   @ Component to manage and monitor system storage resources
   active component StorageManager {
@@ -59,17 +38,17 @@ module components {
     #                                 General Ports                               #
     ###############################################################################
     
-    @ Array of input ports for receiving data from multiple components
-    async input port dataInput: [10] components.StorageData
+    # @ Array of input ports for receiving data from multiple components
+    # async input port dataInput: [10] components.StorageData
     
-    @ Input port for receiving spacecraft state information
-    async input port spacecraftStateIn: components.SystemStateData
+    # @ Input port for receiving spacecraft state information
+    # async input port spacecraftStateIn: components.SystemStateData
     
-    @ Output port for reporting storage status information
-    output port storageStatus: components.StorageStatus
+    # @ Output port for reporting storage status information
+    # output port storageStatus: components.StorageStatus
     
-    @ Array of output ports for sending data to multiple components
-    output port dataOutput: [10] components.StorageData
+    # @ Array of output ports for sending data to multiple components
+    # output port dataOutput: [10] components.StorageData
     
     ###############################################################################
     # Standard AC Ports: Required for Channels, Events, Commands, and Parameters  #
@@ -211,14 +190,14 @@ module components {
     
     @ Event indicating automatic data management action
     event AUTO_MANAGEMENT_ACTION(
-      action: string size 32 @< Type of action taken
+      $action: string size 32 @< Type of action taken
       description: string size 64 @< Description of action
     ) severity activity high id 7 format "Auto management: {} - {}"
     
     @ Event indicating storage health issue
     event STORAGE_HEALTH_ISSUE(
       issue: string size 64 @< Description of health issue
-      severity: string size 16 @< Severity of issue
+      $severity: string size 16 @< Severity of issue
     ) severity warning high id 8 format "Storage health issue detected: {} ({})"
     
     ###############################################################################

--- a/SCALES/Ports/CMakeLists.txt
+++ b/SCALES/Ports/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(SOURCE_FILES
+  "${CMAKE_CURRENT_LIST_DIR}/PowerReading.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/PowerState.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/PowerThermalStatus.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/StorageData.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/StorageStatus.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/SystemStateData.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/ThermalReading.fpp"
+)
+
+register_fprime_module()

--- a/SCALES/Ports/PowerReading.fpp
+++ b/SCALES/Ports/PowerReading.fpp
@@ -1,0 +1,7 @@
+module SCALES{
+    @ Port for receiving power data
+    port powerData(
+        reading: PowerReading
+    )
+    # async input port powerData: components.PowerReading
+}

--- a/SCALES/Ports/PowerState.fpp
+++ b/SCALES/Ports/PowerState.fpp
@@ -1,0 +1,9 @@
+module SCALES{
+    @ Port for receiving power state change requests (e.g., 15W, 30W, 50W)
+    port powerStateRecieve(recieve: PowerState)
+    # async input port powerStateReceive: components.PowerState
+
+    @ Port for sending current power state information
+    port powerStateSend(sendvar: PowerState)
+    # output port powerStateSend: components.PowerState
+}

--- a/SCALES/Ports/PowerThermalStatus.fpp
+++ b/SCALES/Ports/PowerThermalStatus.fpp
@@ -1,0 +1,9 @@
+module SCALES{
+    @ Output port for all power and thermal telemetry data
+    port dataOut(data: PowerThermalStatus)
+    # output port dataOut: components.PowerThermalStatus
+
+    @ Output port for sending power/thermal status to SystemResources component
+    port systemResourcesOut(hotcold: PowerThermalStatus)
+    # output port systemResourcesOut: components.PowerThermalStatus
+}

--- a/SCALES/Ports/StorageData.fpp
+++ b/SCALES/Ports/StorageData.fpp
@@ -1,0 +1,9 @@
+module SCALES{
+    @ Array of input ports for receiving data from multiple components
+    port dataInput(datain: StorageData)
+    # async input port dataInput: [10] components.StorageData
+
+    @ Array of output ports for sending data to multiple components
+    port dataOutput(dataout: StorageData)
+    # output port dataOutput: [10] components.StorageData
+}

--- a/SCALES/Ports/StorageStatus.fpp
+++ b/SCALES/Ports/StorageStatus.fpp
@@ -1,0 +1,5 @@
+module SCALES{
+    @ Output port for reporting storage status information
+    port storageStatus(stat: StorageStatus)
+    # output port storageStatus: components.StorageStatus
+}

--- a/SCALES/Ports/SystemStateData.fpp
+++ b/SCALES/Ports/SystemStateData.fpp
@@ -1,0 +1,9 @@
+module SCALES{
+    @ Input port for receiving spacecraft state information
+    port spacecraftStateIn(rxSpace: SystemStateData)
+    # async input port spacecraftStateIn: components.SystemStateData
+
+    @ Input port for receiving system state information
+    port systemStateIn(rxSystem: SystemStateData)
+    # async input port systemStateIn: components.SystemStateData
+}

--- a/SCALES/Ports/ThermalReading.fpp
+++ b/SCALES/Ports/ThermalReading.fpp
@@ -1,0 +1,5 @@
+module SCALES{
+    @ Port for receiving thermal data
+    port thermalData(rxTemp: ThermalReading)
+    # async input port thermalData: components.ThermalReading
+}

--- a/SCALES/Types/CMakeLists.txt
+++ b/SCALES/Types/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(SOURCE_FILES
+  "${CMAKE_CURRENT_LIST_DIR}/DataTransferRequest.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/PowerLevel.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/PowerReading.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/PowerState.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/PowerThermalStatus.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/StorageData.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/StorageStatus.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/SystemState.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/SystemStateData.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/ThermalReading.fpp"
+)
+
+register_fprime_module()

--- a/SCALES/Types/DataTransferRequest.fpp
+++ b/SCALES/Types/DataTransferRequest.fpp
@@ -1,0 +1,10 @@
+module SCALES{
+    struct DataTransferRequest {
+    sourceComponentId: U8 @< Source component ID
+    destinationComponentId: U8 @< Destination component ID
+    dataType: string size 32 @< Type of data to transfer
+    $priority: U8 @< Priority of transfer
+    maxSizeMB: U32 @< Maximum size to transfer in MB
+    timestamp: U32 @< Timestamp of request
+  }
+}

--- a/SCALES/Types/PowerLevel.fpp
+++ b/SCALES/Types/PowerLevel.fpp
@@ -1,0 +1,8 @@
+module SCALES{
+    enum PowerLevel: U8 {
+    WATTS_15 = 0 @< 15 Watts power state
+    WATTS_30 = 1 @< 30 Watts power state
+    WATTS_50 = 2 @< 50 Watts power state
+    UNKNOWN = 3 @< Power state not determined
+  }
+}

--- a/SCALES/Types/PowerReading.fpp
+++ b/SCALES/Types/PowerReading.fpp
@@ -1,0 +1,9 @@
+module SCALES{
+    struct PowerReading {
+    voltage: F32 @< Voltage reading in volts
+    current: F32 @< Current reading in amps
+    power: F32 @< Power consumption in watts
+    sourceId: U8 @< ID of the power source/sensor
+    timestamp: U32 @< Timestamp of reading
+  }
+}

--- a/SCALES/Types/PowerState.fpp
+++ b/SCALES/Types/PowerState.fpp
@@ -1,0 +1,7 @@
+module SCALES{
+    struct PowerState {
+    level: PowerLevel @< Current power level
+    timestamp: U32 @< Timestamp of state
+    textFilePath: string size 128 @< Path to power state config file
+  }
+}

--- a/SCALES/Types/PowerThermalStatus.fpp
+++ b/SCALES/Types/PowerThermalStatus.fpp
@@ -1,0 +1,9 @@
+module SCALES{
+    struct PowerThermalStatus {
+    powerReadings: PowerReading @< Power readings
+    thermalReadings: ThermalReading @< Thermal readings
+    systemRecommendation: SystemState @< Recommended system state based on power/thermal
+    criticalFlag: bool @< Flag indicating if any readings are in critical range
+    timestamp: U32 @< Timestamp of status update
+  }
+}

--- a/SCALES/Types/StorageData.fpp
+++ b/SCALES/Types/StorageData.fpp
@@ -1,0 +1,10 @@
+module SCALES{
+    struct StorageData {
+    componentId: U8 @< ID of the source/destination component
+    dataType: string size 32 @< Type of data being stored/retrieved
+    dataSize: U32 @< Size of data in bytes
+    $priority: U8 @< Priority level of this data (0-255)
+    timestamp: U32 @< Timestamp of data
+    data: Fw.Buffer @< The actual data payload
+  }
+}

--- a/SCALES/Types/StorageStatus.fpp
+++ b/SCALES/Types/StorageStatus.fpp
@@ -1,0 +1,12 @@
+module SCALES{
+    struct StorageStatus {
+    totalCapacityMB: U32 @< Total storage capacity in MB
+    availableSpaceMB: U32 @< Available storage space in MB
+    usedSpaceMB: U32 @< Used storage space in MB
+    utilizationPercent: F32 @< Storage utilization percentage
+    writeRateKBps: F32 @< Current write rate in KB/s
+    readRateKBps: F32 @< Current read rate in KB/s
+    healthStatus: string size 32 @< Storage health status description
+    timestamp: U32 @< Timestamp of status update
+  }
+}

--- a/SCALES/Types/SystemState.fpp
+++ b/SCALES/Types/SystemState.fpp
@@ -1,0 +1,10 @@
+  module SCALES{
+    enum SystemState: U8 {
+    STANDBY = 0 @< System in standby mode
+    NORMAL = 1 @< System in normal operation
+    SAFE = 2 @< System in safe mode
+    CRITICAL = 3 @< System in critical mode
+    UNKNOWN = 4 @< System state not determined
+    }
+  }
+  

--- a/SCALES/Types/SystemStateData.fpp
+++ b/SCALES/Types/SystemStateData.fpp
@@ -1,0 +1,9 @@
+module SCALES{
+    struct SystemStateData {
+    $state: SystemState @< Current spacecraft state
+    timestamp: U32 @< Timestamp of state update
+    availablePowerForStorage: F32 @< Available power allocation for storage operations (Watts)
+    priorityLevel: U8 @< Current priority level for storage operations
+    modeDescription: string size 64 @< Optional detailed mode description
+  }
+}

--- a/SCALES/Types/ThermalReading.fpp
+++ b/SCALES/Types/ThermalReading.fpp
@@ -1,0 +1,8 @@
+module SCALES{
+    struct ThermalReading {
+    temperature: F32 @< Temperature in degrees Celsius
+    sensorId: U8 @< ID of the thermal sensor
+    location: string size 32 @< Description of sensor location
+    timestamp: U32 @< Timestamp of reading
+  }
+}

--- a/SCALES/library.cmake
+++ b/SCALES/library.cmake
@@ -1,3 +1,0 @@
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Components")
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Types")
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Ports")

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,7 +1,7 @@
-TODO
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/components/JetsonPowerStateManager/")
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/components/PowerThermalManager/")
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/components/StorageManager/")
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/components/FPManager/")
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/components/MLManager/")
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/components/SpacecraftStateManager/")
+
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/SCALES/Components/JetsonPowerStateManager/")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/SCALES/Components/PowerThermalManager/")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/SCALES/Components/StorageManager/")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/SCALES/Components/FPManager/")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/SCALES/Components/MLManager/")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/SCALES/Components/SpacecraftStateManager/")

--- a/cmake/platform/imx8x.cmake
+++ b/cmake/platform/imx8x.cmake
@@ -1,0 +1,87 @@
+####
+# platform.cmake.template:
+#
+# This file acts as a template for the fprime platform files used by the CMake system.
+# These files specify build flags, compiler directives, and must specify an include
+# directory for system includes like "PlatformTypes.hpp".
+#
+# Follow all the steps in this template to create a platform file. Ensure
+# to remove the platform-failsafe (step 1) and fill in all <SOMETHING> tags.
+#
+# **Note:** If the user desires to set compiler paths, and other CMake toolchain settings, a
+#           toolchain file should be constructed. See: [toolchain.md](toolchain.md)
+#
+# ### Platform File Loading ###
+#
+# The user rarely needs to specify a platform file directly. It will be specified based on the data
+# in the chosen Toolchain file, or by the CMake system itself. However, if the user wants to control
+# which platform file is used, the load is specified by the following rules:
+#
+# If the user specifies a CMake Toolchain file, then the platform file `${CMAKE_SYSTEM_NAME}.cmake`
+# will be used. `${CMAKE_SYSTEM_NAME}` is set in the toolchain file and is typically set to a name like Linux, or Darwin
+# but may be more specific if required.
+#
+# Otherwise, CMake sets the `${CMAKE_SYSTEM_NAME}` automatically to be that of the Host system, and that platform
+# will be used. e.g. when building on Linux, the platform file "Linux.cmake" will be used.
+#
+# ### Filling In CMake Platform by Example ###
+#
+# F prime platform files are used to set F prime specific settings. This allows the user to control
+# some aspects of the F prime build at the top-level. This means setting global include directories
+# compiler definitions for the platform, threading libraries, etc. The bare-minimum platform file
+# should specify an include directory for "PlatformTypes.hpp" and a threading library if using
+# active components with OS supported threads. This can be done with the following lines:
+#
+# ```
+# FIND_PACKAGE ( Threads REQUIRED )
+# include_directories(SYSTEM "${FPRIME_FRAMEWORK_PATH}/Fw/Types/Linux")
+# ```
+#
+# **Note:** much of this is done already in *-common.cmake for Linux. If using a linux-like system,
+#           this can be included to save time.
+#
+# **Note:** if copying the template, delete the message with FATAL_ERROR line. This is a fail-safe
+#           to prevent a raw-copy from being treated as a valid toolchain file.
+####
+
+## STEP 1: DELETE the following fail-safe line
+# message(FATAL_ERROR "\n[F-PRIME] Platform must be filled before use.\n")
+
+## STEP 2: Specify the OS type include directive i.e. LINUX or DARWIN
+add_definitions(-DTGT_OS_TYPE_LINUX)
+
+# STEP 3: Specify CMAKE C and CXX compile flags. DO NOT clear existing flags
+set(CMAKE_C_FLAGS
+  "${CMAKE_C_FLAGS} -mcpu=cortex-a35+crc+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/opt/ampliphy-vendor/5.0.4-devel/sysroots/cortexa35-phytec-linux"
+)
+set(CMAKE_CXX_FLAGS
+  "${CMAKE_CXX_FLAGS} -mcpu=cortex-a35+crc+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/opt/ampliphy-vendor/5.0.4-devel/sysroots/cortexa35-phytec-linux"
+)
+
+# STEP 4: Specify that a thread package should be searched in the toolchain
+#         directory. NOTE: when running without threads, remove this line.
+#         Here there is a check for the using baremetal scheduler
+if (NOT DEFINED FPRIME_USE_BAREMETAL_SCHEDULER)
+   set(FPRIME_USE_BAREMETAL_SCHEDULER OFF)
+   message(STATUS "Requiring thread library")
+   FIND_PACKAGE ( Threads REQUIRED )
+endif()
+
+choose_fprime_implementation(Os/File Os/File/Posix)
+choose_fprime_implementation(Os/Console Os/Console/Posix)
+choose_fprime_implementation(Os/Task Os/Task/Posix)
+choose_fprime_implementation(Os/Mutex Os/Mutex/Posix)
+choose_fprime_implementation(Os/Queue Os/Generic/PriorityQueue)
+choose_fprime_implementation(Os/RawTime Os/RawTime/Posix)
+
+choose_fprime_implementation(Os/Cpu Os/Cpu/Stub)
+choose_fprime_implementation(Os/Memory Os/Memory/Stub)
+
+set(FPRIME_USE_POSIX ON)
+# STEP 5: Specify a directory containing the "PlatformTypes.hpp" headers, as well
+#         as other system headers. Other global headers can be placed here.
+#         Note: Typically, the Linux directory is a good default, as it grabs
+#         standard types from <cstdint>.
+add_definitions(-DTGT_OS_TYPE_LINUX)
+# include_directories(SYSTEM "${FPRIME_FRAMEWORK_PATH}/Fw/Types/Linux")
+include_directories(SYSTEM "${CMAKE_CURRENT_LIST_DIR}/types")

--- a/cmake/platform/types/PlatformTypes.h
+++ b/cmake/platform/types/PlatformTypes.h
@@ -1,0 +1,99 @@
+/**
+ * \brief PlatformTypes.h C-compatible type definitions for Linux/Darwin
+ *
+ * PlatformTypes.h is typically published by platform developers to define
+ * the standard available arithmetic types for use in fprime. This standard
+ * types header is designed to support standard Linux/Darwin distributions
+ * running on x86, x86_64 machines and using the standard gcc/clang compilers
+ * shipped with the operating system.
+ *
+ * In C++ code, users may use std::numeric_limits<PlatformIntType>::min()
+ * to reference the min/max limits of a type.
+ */
+#ifndef PLATFORM_TYPES_H_
+#define PLATFORM_TYPES_H_
+
+// Section 0: C Standard Types
+//    fprime depends on the existence of intN_t and uintN_t C standard ints and
+//    the mix/max values for those types. Platform developers must either:
+//    1. define these types and definitions
+//    2. include headers that define these types
+//
+// In addition, support for various type widths can be turned on/off with the
+// switches in this section to control which of the C standard types are
+// available in the system. fprime consumes this information and produces the
+// UN, IN, and FN types we see in fprime code.
+#include <inttypes.h>
+#include <stdint.h>
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+// Define what types and checks are supported by this platform
+#define FW_HAS_64_BIT 1                   //!< Architecture supports 64 bit integers
+#define FW_HAS_32_BIT 1                   //!< Architecture supports 32 bit integers
+#define FW_HAS_16_BIT 1                   //!< Architecture supports 16 bit integers
+#define FW_HAS_F64 1                      //!< Architecture supports 64 bit floating point numbers
+#define SKIP_FLOAT_IEEE_754_COMPLIANCE 0  //!<  Check IEEE 754 compliance of floating point arithmetic
+
+// Section 1: Logical Types
+//    fprime requires platform implementors to define logical types for their
+//    system. The list of logical types can be found in the document:
+//    docs/Design/numerical-types.md with the names of the form "Platform*"
+
+typedef int PlatformIntType;
+#define PRI_PlatformIntType "d"
+
+typedef unsigned int PlatformUIntType;
+#define PRI_PlatformUIntType "u"
+
+typedef PlatformIntType PlatformIndexType;
+#define PRI_PlatformIndexType PRI_PlatformIntType
+
+typedef int64_t PlatformSignedSizeType;
+#define PRI_PlatformSignedSizeType PRId64
+
+typedef uint64_t PlatformSizeType;
+#define PRI_PlatformSizeType PRIu64
+
+typedef PlatformIntType PlatformAssertArgType;
+#define PRI_PlatformAssertArgType PRI_PlatformIntType
+
+typedef PlatformIntType PlatformTaskPriorityType;
+#define PRI_PlatformTaskPriorityType PRI_PlatformIntType
+
+typedef PlatformIntType PlatformQueuePriorityType;
+#define PRI_PlatformQueuePriorityType PRI_PlatformIntType
+
+// Linux/Darwin definitions for pointer have various sizes across platforms
+// and since these definitions need to be consistent we must ask the size.
+#ifndef PLATFORM_POINTER_CAST_TYPE_DEFINED
+// Check for __SIZEOF_POINTER__ or cause error
+#ifndef __SIZEOF_POINTER__
+#error "Compiler does not support __SIZEOF_POINTER__, cannot use Linux/Darwin types"
+#endif
+
+// Pointer sizes are determined by compiler
+#if __SIZEOF_POINTER__ == 8
+typedef uint64_t PlatformPointerCastType;
+#define PRI_PlatformPointerCastType PRIx64
+#elif __SIZEOF_POINTER__ == 4
+typedef uint32_t PlatformPointerCastType;
+#define PRI_PlatformPointerCastType PRIx32
+#elif __SIZEOF_POINTER__ == 2
+typedef uint16_t PlatformPointerCastType;
+#define PRI_PlatformPointerCastType PRIx16
+#elif __SIZEOF_POINTER__ == 1
+typedef uint8_t PlatformPointerCastType;
+#define PRI_PlatformPointerCastType PRIx8
+#else
+#error "Expected __SIZEOF_POINTER__ to be one of 8, 4, 2, or 1"
+#endif
+#endif  // PLATFORM_POINTER_CAST_TYPE_DEFINED
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif  // PLATFORM_TYPES_H_

--- a/cmake/toolchain/imx8x.cmake
+++ b/cmake/toolchain/imx8x.cmake
@@ -1,0 +1,62 @@
+####
+# Template toolchain.cmake.template: 
+#
+# This file acts as a template for the cmake toolchains. These toolchain files
+# specify what tools to use when performing the build as part of CMake. This
+# file can be used to quickly set one up.
+#
+# Follow all the steps in this template to create a toolchain file. Ensure
+# to remove the template-failsafe (step 1) and fill in all <SOMETHING> tags.
+#
+# **Note:** this file should follow the standard CMake toolchain format. See:
+# https://cmake.org/cmake/help/v3.12/manual/cmake-toolchains.7.html
+#
+# **Note:** If the user desires to set compile flags, or F prime specific build options, a platform
+#           file should be constructed. See: [platform.md](platform.md)
+#
+# ### Filling In CMake Toolchain by Example ###
+#
+# CMake Toolchain files, at the most basic, define the system name and C and C++ compilers. In
+# addition, a find path can be set to search for other utilities. This example will walk through
+# setting these values using the appropriate variables. These can be specified using the following
+# CMake setting flags:
+#
+# ```
+# CMAKE_SYSTEM_NAME "RaspberryPI"
+# # specify the cross compiler
+# set(CMAKE_C_COMPILER "/opt/rpi/bin/arm-linux-gnueabihf-gcc")
+# set(CMAKE_CXX_COMPILER "/opt/rpi/bin/arm-linux-gnueabihf-g++")
+# # where is the target environment
+# set(CMAKE_FIND_ROOT_PATH  "/opt/rpi")
+# ```
+#
+# **Note:** if copying the template, delete the message with FATAL_ERROR line. This is a fail-safe
+#           to prevent a raw-copy from being treated as a valid toolchain file. 
+####
+
+## STEP 1: DELETE the following fail-safe line
+
+
+## STEP 2: Specify the target system's name. i.e. raspberry-pi-3
+set(CMAKE_SYSTEM_NAME "imx8x")
+
+# STEP 3: Specify the path to C and CXX cross compilers
+set (CMAKE_C_COMPILER "/opt/ampliphy-vendor/5.0.4-devel/sysroots/x86_64-phytecsdk-linux/usr/bin/aarch64-phytec-linux/aarch64-phytec-linux-gcc")
+set (CMAKE_CXX_COMPILER "/opt/ampliphy-vendor/5.0.4-devel/sysroots/x86_64-phytecsdk-linux/usr/bin/aarch64-phytec-linux/aarch64-phytec-linux-g++")
+add_compile_options(-O -mcpu=cortex-a35+crc+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/opt/ampliphy-vendor/5.0.4-devel/sysroots/cortexa35-phytec-linux)
+set(CMAKE_C_COMPILER_WORKS 1)
+set(CMAKE_CXX_COMPILER_WORKS 1)
+
+
+# STEP 4: Specify paths to root of toolchain package, for searching for
+#         libraries, executables, etc.
+set (CMAKE_FIND_ROOT_PATH "/opt/ampliphy-vendor")
+
+# DO NOT EDIT: F prime searches the host for programs, not the cross
+# compile toolchain
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# DO NOT EDIT: F prime searches for libs, includes, and packages in the
+# toolchain when cross-compiling.
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/library.cmake
+++ b/library.cmake
@@ -1,0 +1,3 @@
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/SCALES/Components/")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/SCALES/Types/")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/SCALES/Ports/")


### PR DESCRIPTION
### Main changes to `fprime-scales` repo:

- Added this repo to [SCALES-IMXDEPLOYMENT](https://github.com/BroncoSpace-Lab/SCALES-IMXDEPLOYMENT) as a submodule in the libs/ folder.
- Made Types and Ports folders to reorganize the type and port definitions 
- Moved all type and port definitions from `JetsonPowerStateManager`, `PowerThermalManager`, and `StorageManager` to .fpp files of the same port/type name in the corresponding port/type folders.
- Changed the way the ports were being defined (had to be defined differently outside the Component fpp file).
- Made CMakeLists for Types and Ports folders

### Things that need to be addressed in future development:

- Make sure the port calls actually work in the component files. The type calls should work fine now, but the port calls may need to be changed with the new definitions.
- General testing to make sure these components/reference deployment actually work on the imx. Not sure if this has been tested previously.
- Consider changing the `SCALES/Components` folder to be named something else, like `SCALES/Svc`. This will result in some path changes throughout the repo.
- Updating the README with more detail about what this repo is for.